### PR TITLE
Update .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-	"presets": ["latest", "stage-0", "react"]
+	"presets": ["env", "stage-0", "react"]
 }


### PR DESCRIPTION
preset-latest is deprecated
{ "presets": ["latest"] } === { "presets": ["env"] }