### PR TITLE
添加middleware/console.js，保证对全局的console及console方法访问时不会报错

### DIFF
--- a/entry/client.js
+++ b/entry/client.js
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom'
 import createApp from 'create-app/lib/client'
+import '../middleware/console'
 import util from '../util'
 import $routes from '@routes'
 

--- a/entry/server.js
+++ b/entry/server.js
@@ -8,6 +8,7 @@ import bodyParser from 'body-parser'
 import favicon from 'serve-favicon'
 import helmet from 'helmet'
 import ReactViews from 'express-react-views'
+import '../middleware/console'
 import shareRoot from '../middleware/shareRoot'
 
 export default function createExpressApp(config) {

--- a/entry/server.js
+++ b/entry/server.js
@@ -8,7 +8,6 @@ import bodyParser from 'body-parser'
 import favicon from 'serve-favicon'
 import helmet from 'helmet'
 import ReactViews from 'express-react-views'
-import '../middleware/console'
 import shareRoot from '../middleware/shareRoot'
 
 export default function createExpressApp(config) {

--- a/middleware/console.js
+++ b/middleware/console.js
@@ -2,8 +2,8 @@
  * 对console未定义及console方法未定义时，补充定义空对象、空函数，防止报错
  * 如IE 9在未开启过Dev Tools时，console对象将会是未定义
  */
-var _stubConsole = function stubConsole(global) {
-    // Avoid `console` errors in global/browsers that lack a console.
+var _stubConsole = function stubConsole(window) {
+    // Avoid `console` errors in browsers that lack a console.
     var method;
     var noop = function () {
     };
@@ -14,7 +14,7 @@ var _stubConsole = function stubConsole(global) {
         'timeline', 'timelineEnd', 'timeStamp', 'trace', 'warn', 'msIsIndependentlyComposed'
     ];
     var length = methods.length;
-    var console = (global.console = global.console || {});
+    var console = (window.console = window.console || {});
 
     while (length--) {
         method = methods[length];
@@ -26,6 +26,6 @@ var _stubConsole = function stubConsole(global) {
     }
 };
 
-_stubConsole(typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {});
+_stubConsole(typeof window !== "undefined" ? window : {});
 
 module.exports = _stubConsole;

--- a/middleware/console.js
+++ b/middleware/console.js
@@ -1,0 +1,31 @@
+/**
+ * 对console未定义及console方法未定义时，补充定义空对象、空函数，防止报错
+ * 如IE 9在未开启过Dev Tools时，console对象将会是未定义
+ */
+var _stubConsole = function stubConsole(global) {
+    // Avoid `console` errors in global/browsers that lack a console.
+    var method;
+    var noop = function () {
+    };
+    var methods = [
+        'assert', 'clear', 'count', 'debug', 'dir', 'dirxml', 'error',
+        'exception', 'group', 'groupCollapsed', 'groupEnd', 'info', 'log',
+        'markTimeline', 'profile', 'profileEnd', 'table', 'time', 'timeEnd',
+        'timeline', 'timelineEnd', 'timeStamp', 'trace', 'warn', 'msIsIndependentlyComposed'
+    ];
+    var length = methods.length;
+    var console = (global.console = global.console || {});
+
+    while (length--) {
+        method = methods[length];
+
+        // Only stub undefined methods.
+        if (!console[method]) {
+            console[method] = noop;
+        }
+    }
+};
+
+_stubConsole(typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {});
+
+module.exports = _stubConsole;


### PR DESCRIPTION
解决IE9下未开启开发者工具时，无法访问全局console对象的问题。