### PR TITLE
change sourcemap config in dev env pr

### DIFF
--- a/config/config.defaults.js
+++ b/config/config.defaults.js
@@ -118,7 +118,7 @@ module.exports = {
 	/**
 	 * webpack devtool 配置
 	 */
-	devtool: isDev ? 'source-map' : '',
+	devtool: isDev ? 'cheap-module-eval-source-map' : '',
 
 	/**
 	 * 是否开启 webpack 的构建产物进行可视化分析


### PR DESCRIPTION
在接手一个imvc项目过程中，发现chrome下 debugger 的断点打不到指定位置
https://github.com/webpack/webpack/issues/2145

通过查阅资料 ，发现
cheap-module-eval-source-map 是比较好的一种方式，
https://juejin.im/post/58293502a0bb9f005767ba2f