### PR TITLE
fix: set webpack config resolve.mainFields defaults to [browser, main…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 2.9.9
+- fix: 修改 webpack 配置的 resolve.mainFields 指定为 ['browser', 'main']，避免引入 esm 模块引发的问题
+
+## 2.9.8
+- fix: fix bug when lazy component is loaded before useEffect called
+
 ## 2.9.7
 
 - fix: 修复写死 express ~v.4.14.0 的问题

--- a/build/createWebpackConfig.js
+++ b/build/createWebpackConfig.js
@@ -234,6 +234,7 @@ module.exports = function createWebpackConfig(options, isServer = false) {
 			...config.performance
 		},
 		resolve: {
+			mainFields: ['browser', 'main'],
 			modules: ['node_modules'],
 			extensions: ['.js', '.jsx', '.json', '.mjs', '.ts', '.tsx'],
 			alias: alias,


### PR DESCRIPTION
修改 webpack 配置的 resolve.mainFields 指定为 ['browser', 'main']，避免引入 esm 模块引发的问题